### PR TITLE
Added public access to the pixels Vec of an Image

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -25,7 +25,7 @@ use std::{
 pub struct Image {
     width: usize,
     height: usize,
-    pixels: Vec<Color>,
+    pub pixels: Vec<Color>,
 }
 
 /// A row/column pair for indexing into an image.


### PR DESCRIPTION
Giving access to the pixels of an Image is necessary for some situations.  
If someone wants to set a pixel at a specific location for example.  
Or to override lots of data at once.  

This avoids verbosely creating a buffer, iterating over the image and setting the buffer contents