### PR TITLE
Switch back to packed_simd dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ glium = "0.31.0"
 rayon = "1.5"
 rand = "0.8"
 rand_distr = "0.4"
-packed_simd = { version = "0.3.6", package = "packed_simd_2" }
+packed_simd = "0.3.9"


### PR DESCRIPTION
packed_simd is now again being published under its original name.